### PR TITLE
#12 Feed CRUD

### DIFF
--- a/feed/build.gradle.kts
+++ b/feed/build.gradle.kts
@@ -1,0 +1,8 @@
+dependencies {
+    implementation(project(":feed:internal-api"))
+    implementation(project(":feed:model"))
+    implementation(project(":feed:persist"))
+    implementation(project(":feed:repository"))
+    implementation(project(":feed:service"))
+    implementation(project(":feed:use-case"))
+}

--- a/feed/gradle.properties
+++ b/feed/gradle.properties
@@ -1,0 +1,1 @@
+type=kotlin-boot-mvc-application

--- a/feed/internal-api/build.gradle.kts
+++ b/feed/internal-api/build.gradle.kts
@@ -1,0 +1,4 @@
+dependencies {
+    implementation(project(":feed:use-case"))
+    implementation(project(":feed:model"))
+}

--- a/feed/internal-api/gradle.properties
+++ b/feed/internal-api/gradle.properties
@@ -1,0 +1,1 @@
+type=kotlin-boot-mvc

--- a/feed/internal-api/src/main/kotlin/com/gongsung/feed/FeedController.kt
+++ b/feed/internal-api/src/main/kotlin/com/gongsung/feed/FeedController.kt
@@ -36,6 +36,22 @@ class FeedController(
             .let(FeedIdentity.Companion::of)
             .run(getFeedUseCase::getFeed)
     }
+
+    @PostMapping("/{feedId}/like")
+    fun like(
+        @PathVariable feedId: Long,
+        @RequestBody request: FeedLikeRequest,
+    ) {
+        commandFeedUseCase.like(feedId, request.userId)
+    }
+
+    @PostMapping("/{feedId}/dislike")
+    fun dislike(
+        @PathVariable feedId: Long,
+        @RequestBody request: FeedLikeRequest,
+    ) {
+        commandFeedUseCase.dislike(feedId, request.userId)
+    }
 }
 
 data class CreateFeedRequest(
@@ -58,3 +74,7 @@ data class UpdateFeedRequest(
 
     override val time: LocalTime = LocalTime.now()
 }
+
+data class FeedLikeRequest(
+    val userId: Long,
+)

--- a/feed/internal-api/src/main/kotlin/com/gongsung/feed/FeedController.kt
+++ b/feed/internal-api/src/main/kotlin/com/gongsung/feed/FeedController.kt
@@ -1,0 +1,60 @@
+package com.gongsung.feed
+
+import org.springframework.web.bind.annotation.*
+import java.time.LocalDate
+import java.time.LocalTime
+
+@RestController
+@RequestMapping("/internal/v1/feeds")
+class FeedController(
+    private val commandFeedUseCase: CommandFeedUseCase,
+    private val getFeedUseCase: GetFeedUseCase,
+) {
+
+    @PostMapping
+    fun create(@RequestBody request: CreateFeedRequest): FeedModel {
+        return commandFeedUseCase.create(request)
+    }
+
+    @PutMapping
+    fun update(@RequestBody request: UpdateFeedRequest): FeedModel {
+        return commandFeedUseCase.update(request.feedId, request)
+    }
+
+    @DeleteMapping("/{feedId}")
+    fun delete(
+        @PathVariable feedId: Long,
+    ) {
+        commandFeedUseCase.delete(FeedIdentity.of(feedId))
+    }
+
+    @GetMapping("/{feedId}")
+    fun getFeed(
+        @PathVariable feedId: Long,
+    ): FeedModel {
+        return feedId
+            .let(FeedIdentity.Companion::of)
+            .run(getFeedUseCase::getFeed)
+    }
+}
+
+data class CreateFeedRequest(
+    override val publisherId: Long,
+    override val contents: String,
+) : FeedProps {
+
+    override val date: LocalDate = LocalDate.now()
+
+    override val time: LocalTime = LocalTime.now()
+}
+
+data class UpdateFeedRequest(
+    val feedId: Long,
+    override val publisherId: Long,
+    override val contents: String,
+) : FeedProps {
+
+    override val date: LocalDate = LocalDate.now()
+
+    override val time: LocalTime = LocalTime.now()
+}

--- a/feed/model/gradle.properties
+++ b/feed/model/gradle.properties
@@ -1,0 +1,1 @@
+type=kotlin-lib

--- a/feed/model/src/main/kotlin/com.gongsung.feed/Feed.kt
+++ b/feed/model/src/main/kotlin/com.gongsung.feed/Feed.kt
@@ -31,3 +31,7 @@ interface FeedDetail {
 data class FeedIdentityImpl(
     override val feedId: Long,
 ) : FeedIdentity
+
+interface FeedLike {
+    var likeCount: Long
+}

--- a/feed/model/src/main/kotlin/com.gongsung.feed/Feed.kt
+++ b/feed/model/src/main/kotlin/com.gongsung.feed/Feed.kt
@@ -1,0 +1,33 @@
+package com.gongsung.feed
+
+import java.time.LocalDate
+import java.time.LocalTime
+
+interface FeedModel : FeedIdentity, FeedProps, FeedLike
+
+interface FeedIdentity {
+    val feedId: Long
+
+    companion object {
+        fun of(id: Long) = FeedIdentityImpl(feedId = id)
+    }
+}
+
+interface FeedProps : FeedDetail {
+    val publisherId: Long
+}
+
+interface PublisherInfo {
+    val publisherId: Long
+    val publisherName: String
+}
+
+interface FeedDetail {
+    val date: LocalDate
+    val time: LocalTime
+    val contents: String
+}
+
+data class FeedIdentityImpl(
+    override val feedId: Long,
+) : FeedIdentity

--- a/feed/model/src/main/kotlin/com.gongsung.feed/Like.kt
+++ b/feed/model/src/main/kotlin/com.gongsung.feed/Like.kt
@@ -1,0 +1,6 @@
+package com.gongsung.feed
+
+interface LikeModel {
+    val feedId: Long
+    val userId: Long
+}

--- a/feed/persist/build.gradle.kts
+++ b/feed/persist/build.gradle.kts
@@ -1,0 +1,3 @@
+dependencies {
+    implementation(project(":feed:model"))
+}

--- a/feed/persist/gradle.properties
+++ b/feed/persist/gradle.properties
@@ -1,0 +1,1 @@
+type=kotlin

--- a/feed/persist/src/main/kotlin/com/gongsung/feed/CommandFeedPersist.kt
+++ b/feed/persist/src/main/kotlin/com/gongsung/feed/CommandFeedPersist.kt
@@ -7,4 +7,8 @@ interface CommandFeedPersist {
     fun update(feedId: Long, feedProps: FeedProps): FeedModel
 
     fun delete(id: Long)
+
+    fun increaseLikes(feedId: Long)
+
+    fun decreaseLikes(feedId: Long)
 }

--- a/feed/persist/src/main/kotlin/com/gongsung/feed/CommandFeedPersist.kt
+++ b/feed/persist/src/main/kotlin/com/gongsung/feed/CommandFeedPersist.kt
@@ -1,0 +1,10 @@
+package com.gongsung.feed
+
+interface CommandFeedPersist {
+
+    fun create(feedProps: FeedProps): FeedModel
+
+    fun update(feedId: Long, feedProps: FeedProps): FeedModel
+
+    fun delete(id: Long)
+}

--- a/feed/persist/src/main/kotlin/com/gongsung/feed/CommandLikePersist.kt
+++ b/feed/persist/src/main/kotlin/com/gongsung/feed/CommandLikePersist.kt
@@ -1,0 +1,8 @@
+package com.gongsung.feed
+
+interface CommandLikePersist {
+
+    fun create(feedId: Long, userId: Long)
+
+    fun delete(feedId: Long, userId: Long)
+}

--- a/feed/persist/src/main/kotlin/com/gongsung/feed/QueryFeedPersist.kt
+++ b/feed/persist/src/main/kotlin/com/gongsung/feed/QueryFeedPersist.kt
@@ -1,0 +1,6 @@
+package com.gongsung.feed
+
+interface QueryFeedPersist {
+
+    fun findById(id: Long): FeedModel
+}

--- a/feed/repository/build.gradle.kts
+++ b/feed/repository/build.gradle.kts
@@ -1,0 +1,4 @@
+dependencies {
+    implementation(project(":feed:model"))
+    implementation(project(":feed:persist"))
+}

--- a/feed/repository/gradle.properties
+++ b/feed/repository/gradle.properties
@@ -1,0 +1,1 @@
+type=kotlin-boot-jpa-querydsl-repository

--- a/feed/repository/src/main/kotlin/com/gongsung/feed/FeedMemoryRepository.kt
+++ b/feed/repository/src/main/kotlin/com/gongsung/feed/FeedMemoryRepository.kt
@@ -1,0 +1,42 @@
+package com.gongsung.feed
+
+import com.gongsung.feed.entity.Feed
+import org.springframework.stereotype.Repository
+import java.lang.IllegalArgumentException
+import java.lang.IllegalStateException
+import java.util.concurrent.atomic.AtomicLong
+
+@Repository
+internal class FeedMemoryRepository : CommandFeedPersist, QueryFeedPersist {
+
+    companion object {
+        var FEED_ID = AtomicLong(-1)
+    }
+
+    private val repository = mutableMapOf<Long, FeedModel>()
+
+    override fun create(feedProps: FeedProps): FeedModel {
+        val feedId = FEED_ID.getAndIncrement()
+        val feed = Feed.of(feedId, feedProps)
+
+        repository[feedId] = feed
+        return feed
+    }
+
+    override fun update(feedId: Long, feedProps: FeedProps): FeedModel {
+        repository[feedId] ?: throw IllegalArgumentException("Feed 조회 중 에러 발생.")
+
+        repository[feedId] = Feed.of(feedId, feedProps)
+        return repository[feedId] ?: throw IllegalStateException("Feed Update 중 에러 발생.")
+    }
+
+    override fun delete(id: Long) {
+
+        repository.remove(id)
+    }
+
+    override fun findById(id: Long): FeedModel {
+
+        return repository[id] ?: throw IllegalArgumentException("Feed 조회 중 에러 발생.")
+    }
+}

--- a/feed/repository/src/main/kotlin/com/gongsung/feed/FeedMemoryRepository.kt
+++ b/feed/repository/src/main/kotlin/com/gongsung/feed/FeedMemoryRepository.kt
@@ -39,4 +39,14 @@ internal class FeedMemoryRepository : CommandFeedPersist, QueryFeedPersist {
 
         return repository[id] ?: throw IllegalArgumentException("Feed 조회 중 에러 발생.")
     }
+
+    override fun increaseLikes(feedId: Long) {
+        val feed = repository[feedId] ?: throw IllegalArgumentException("Feed 조회 중 에러 발생.")
+        feed.likeCount += 1
+    }
+
+    override fun decreaseLikes(feedId: Long) {
+        val feed = repository[feedId] ?: throw IllegalArgumentException("Feed 조회 중 에러 발생.")
+        feed.likeCount -= 1
+    }
 }

--- a/feed/repository/src/main/kotlin/com/gongsung/feed/LikeMemoryRepository.kt
+++ b/feed/repository/src/main/kotlin/com/gongsung/feed/LikeMemoryRepository.kt
@@ -1,0 +1,21 @@
+package com.gongsung.feed
+
+import com.gongsung.feed.entity.Like
+import com.gongsung.feed.entity.LikePK
+import org.springframework.stereotype.Repository
+
+@Repository
+internal class LikeMemoryRepository : CommandLikePersist {
+
+    private val repository = mutableMapOf<LikePK, LikeModel>()
+
+    override fun create(feedId: Long, userId: Long) {
+        val key = LikePK(userId, feedId)
+        repository[key] = Like.of(key)
+    }
+
+    override fun delete(feedId: Long, userId: Long) {
+        val key = LikePK(userId, feedId)
+        repository.remove(key)
+    }
+}

--- a/feed/repository/src/main/kotlin/com/gongsung/feed/entity/Feed.kt
+++ b/feed/repository/src/main/kotlin/com/gongsung/feed/entity/Feed.kt
@@ -20,6 +20,7 @@ class Feed(
     override val date: LocalDate = LocalDate.now(),
     override val time: LocalTime = LocalTime.now(),
     override val contents: String = "",
+    override var likeCount: Long = 0,
 ) : FeedModel {
 
     companion object {

--- a/feed/repository/src/main/kotlin/com/gongsung/feed/entity/Feed.kt
+++ b/feed/repository/src/main/kotlin/com/gongsung/feed/entity/Feed.kt
@@ -1,0 +1,34 @@
+package com.gongsung.feed.entity
+
+import com.gongsung.feed.FeedModel
+import com.gongsung.feed.FeedProps
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import java.time.LocalDate
+import java.time.LocalTime
+
+@Entity
+class Feed(
+    @Id
+    @Column(nullable = false, updatable = false)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    override val feedId: Long = -1,
+    override val publisherId: Long = 1,
+    override val date: LocalDate = LocalDate.now(),
+    override val time: LocalTime = LocalTime.now(),
+    override val contents: String = "",
+) : FeedModel {
+
+    companion object {
+        fun of(feedId: Long, feed: FeedProps) = Feed(
+            feedId = feedId,
+            publisherId = feed.publisherId,
+            date = feed.date,
+            time = feed.time,
+            contents = feed.contents,
+        )
+    }
+}

--- a/feed/repository/src/main/kotlin/com/gongsung/feed/entity/Like.kt
+++ b/feed/repository/src/main/kotlin/com/gongsung/feed/entity/Like.kt
@@ -1,0 +1,28 @@
+package com.gongsung.feed.entity
+
+import com.gongsung.feed.LikeModel
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.IdClass
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "like_info")
+@IdClass(LikePK::class)
+class Like(
+    @Id
+    @Column(nullable = false, updatable = false)
+    override val userId: Long = -1,
+    @Id
+    @Column(nullable = false, updatable = false)
+    override val feedId: Long = -1,
+) : LikeModel {
+
+    companion object {
+        fun of(key: LikePK) = Like(
+            userId = key.userId,
+            feedId = key.feedId
+        )
+    }
+}

--- a/feed/repository/src/main/kotlin/com/gongsung/feed/entity/LikePK.kt
+++ b/feed/repository/src/main/kotlin/com/gongsung/feed/entity/LikePK.kt
@@ -1,0 +1,8 @@
+package com.gongsung.feed.entity
+
+import java.io.Serializable
+
+data class LikePK(
+    val userId: Long,
+    val feedId: Long,
+) : Serializable

--- a/feed/repository/src/main/resources/application-repository.yml
+++ b/feed/repository/src/main/resources/application-repository.yml
@@ -1,0 +1,7 @@
+spring:
+  profiles:
+    group:
+      local-repository: local-datasource
+  config:
+    import:
+      - config/db.yml

--- a/feed/repository/src/main/resources/config/db.yml
+++ b/feed/repository/src/main/resources/config/db.yml
@@ -1,0 +1,20 @@
+spring.config.activate.on-profile: local-datasource
+
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/meetin?autoReconnect=true&characterEncoding=UTF-8&useSSL=false&serverZoneId=UTC
+    username: root
+    password: 1234
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    properties:
+      hibernate:
+        default_batch_fetch_size: 1000
+        show_sql: false
+        format_sql: false
+        order_by.default_null_ordering: first
+    open-in-view: false
+    database: mysql
+    database-platform: org.hibernate.dialect.MySQL8Dialect
+    hibernate:
+      ddl-auto: create

--- a/feed/service/build.gradle.kts
+++ b/feed/service/build.gradle.kts
@@ -1,0 +1,5 @@
+dependencies {
+    implementation(project(":feed:use-case"))
+    implementation(project(":feed:persist"))
+    implementation(project(":feed:model"))
+}

--- a/feed/service/gradle.properties
+++ b/feed/service/gradle.properties
@@ -1,0 +1,1 @@
+type=kotlin-boot-lib

--- a/feed/service/src/main/kotlin/com/gongsung/feed/FeedService.kt
+++ b/feed/service/src/main/kotlin/com/gongsung/feed/FeedService.kt
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service
 class FeedService(
     private val commandFeedPersist: CommandFeedPersist,
     private val queryFeedPersist: QueryFeedPersist,
+    private val commandLikePersist: CommandLikePersist,
 ) : CommandFeedUseCase, GetFeedUseCase {
     override fun create(feedProps: FeedProps): FeedModel {
         return commandFeedPersist.create(feedProps)
@@ -20,6 +21,25 @@ class FeedService(
 
     override fun delete(id: FeedIdentity) {
         return commandFeedPersist.delete(id.feedId)
+    }
+
+    override fun like(
+        feedId: Long,
+        userId: Long,
+    ) {
+        // TODO 동시성 이슈 해결해야함
+        commandFeedPersist.increaseLikes(feedId)
+
+        commandLikePersist.create(feedId, userId)
+    }
+
+    override fun dislike(
+        feedId: Long,
+        userId: Long,
+    ) {
+        commandFeedPersist.decreaseLikes(feedId)
+
+        commandLikePersist.delete(feedId, userId)
     }
 
     override fun getFeed(id: FeedIdentity): FeedModel {

--- a/feed/service/src/main/kotlin/com/gongsung/feed/FeedService.kt
+++ b/feed/service/src/main/kotlin/com/gongsung/feed/FeedService.kt
@@ -1,0 +1,28 @@
+package com.gongsung.feed
+
+import org.springframework.stereotype.Service
+
+@Service
+class FeedService(
+    private val commandFeedPersist: CommandFeedPersist,
+    private val queryFeedPersist: QueryFeedPersist,
+) : CommandFeedUseCase, GetFeedUseCase {
+    override fun create(feedProps: FeedProps): FeedModel {
+        return commandFeedPersist.create(feedProps)
+    }
+
+    override fun update(
+        feedId: Long,
+        feedProps: FeedProps,
+    ): FeedModel {
+        return commandFeedPersist.update(feedId, feedProps)
+    }
+
+    override fun delete(id: FeedIdentity) {
+        return commandFeedPersist.delete(id.feedId)
+    }
+
+    override fun getFeed(id: FeedIdentity): FeedModel {
+        return queryFeedPersist.findById(id.feedId)
+    }
+}

--- a/feed/src/main/kotlin/com/gongsung/feed/FeedApplication.kt
+++ b/feed/src/main/kotlin/com/gongsung/feed/FeedApplication.kt
@@ -1,0 +1,11 @@
+package com.gongsung.feed
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+
+@SpringBootApplication
+class FeedApplication
+
+fun main(args: Array<String>) {
+    runApplication<FeedApplication>(*args)
+}

--- a/feed/src/main/resources/application.yml
+++ b/feed/src/main/resources/application.yml
@@ -1,0 +1,9 @@
+spring:
+  profiles:
+    group:
+      local: local-repository
+  config:
+    import:
+      - application-repository.yml
+server:
+  port: 8082

--- a/feed/use-case/build.gradle.kts
+++ b/feed/use-case/build.gradle.kts
@@ -1,0 +1,3 @@
+dependencies {
+    implementation(project(":feed:model"))
+}

--- a/feed/use-case/gradle.properties
+++ b/feed/use-case/gradle.properties
@@ -1,0 +1,1 @@
+type=kotlin-lib

--- a/feed/use-case/src/main/kotlin/com/gongsung/feed/CommandFeedUseCase.kt
+++ b/feed/use-case/src/main/kotlin/com/gongsung/feed/CommandFeedUseCase.kt
@@ -7,4 +7,8 @@ interface CommandFeedUseCase {
     fun update(feedId: Long, feedProps: FeedProps): FeedModel
 
     fun delete(id: FeedIdentity)
+
+    fun like(feedId: Long, userId: Long)
+
+    fun dislike(feedId: Long, userId: Long)
 }

--- a/feed/use-case/src/main/kotlin/com/gongsung/feed/CommandFeedUseCase.kt
+++ b/feed/use-case/src/main/kotlin/com/gongsung/feed/CommandFeedUseCase.kt
@@ -1,0 +1,10 @@
+package com.gongsung.feed
+
+interface CommandFeedUseCase {
+
+    fun create(feedProps: FeedProps): FeedModel
+
+    fun update(feedId: Long, feedProps: FeedProps): FeedModel
+
+    fun delete(id: FeedIdentity)
+}

--- a/feed/use-case/src/main/kotlin/com/gongsung/feed/GetFeedUseCase.kt
+++ b/feed/use-case/src/main/kotlin/com/gongsung/feed/GetFeedUseCase.kt
@@ -1,0 +1,6 @@
+package com.gongsung.feed
+
+interface GetFeedUseCase {
+
+    fun getFeed(id: FeedIdentity): FeedModel
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -53,3 +53,10 @@ dependencyResolutionManagement {
         gradlePluginPortal()
     }
 }
+include("feed")
+include("feed:model")
+include("feed:internal-api")
+include("feed:service")
+include("feed:use-case")
+include("feed:repository")
+include("feed:persist")


### PR DESCRIPTION
## 작업내용
1. Feed CRUD 개발
- 아직 DB를 안붙여서, memory repository로 개발. 추후 MySql로 전환 예정.

## 학습내용 및 논의점
1. model interface
- DTO-model-Entity를 interface 기반으로 구현하는 방식이 처음이라 낯설었던 것 같다. 맛본 결과, 장단점이 뚜렷해 보임.
  - 장점) 객체 매핑 오버헤드가 현저히 줄어들었다! 매핑 전략도 크게 신경쓰지 않아도 돼서 좋다.
  - 단점) 서비스 레이어 테스트코드 작성이 어렵다. 낯선 방식이라 코드 짜는 데에 조금 시간이 걸렸다.
- 다같이 써보면서 어떤 방식이 더 좋은지 결정을 내리면 될 것 같다.

2. 모듈 네이밍에 대해
- 현재 모듈간 의존 관계 및 이름은 api -> use-case <- service -> persist <- repository 로 결정됨.
- 이름은 레이어드 아키텍처에서 쓰는 형태지만, 의존 관계는 클린 아키텍처(헥사고날 등)을 모방함.
- 네이밍과 의존관계가 하나가 아닌 여러개의 아키텍처 이론을 기반으로 하다보니, 개발할 때 헷갈리는 부분들이 발생하는 것 같다.
- 나중에 기회가 된다면 아키텍처 하나를 완전히 정해서 (레이어드, 헥사고날, 어니언..) 리팩토링 해보고 장단점 비교해보는 것도 재밌겠다.