### PR TITLE
Redis 분산락

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -182,3 +182,9 @@ configureByTypeHaving("client") {
         implementation("org.springframework.cloud:spring-cloud-starter-openfeign:$feignClientVersion")
     }
 }
+
+configureByTypeHaving("redis") {
+    dependencies {
+        implementation("org.redisson:redisson-spring-boot-starter:3.26.1")
+    }
+}

--- a/common/infrastructure/gradle.properties
+++ b/common/infrastructure/gradle.properties
@@ -1,0 +1,1 @@
+type=kotlin-redis-lib

--- a/common/infrastructure/src/main/kotlin/com/gongsung/common/InfrastructureApplication.kt
+++ b/common/infrastructure/src/main/kotlin/com/gongsung/common/InfrastructureApplication.kt
@@ -1,0 +1,11 @@
+package com.gongsung.common
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+
+@SpringBootApplication
+open class InfrastructureApplication
+
+fun main(args: Array<String>) {
+    runApplication<InfrastructureApplication>(*args)
+}

--- a/common/infrastructure/src/main/kotlin/com/gongsung/common/infrastructure/LockModel.kt
+++ b/common/infrastructure/src/main/kotlin/com/gongsung/common/infrastructure/LockModel.kt
@@ -1,0 +1,23 @@
+package com.gongsung.common.infrastructure
+
+import com.gongsung.common.infrastructure.redis.LockType
+
+data class Options(
+    val waitTimeout: Long,
+    val releaseTimeout: Long,
+)
+
+fun <T> LockContext.newLockScope() = object : LockScope<T> {
+    override val lockContext: LockContext = this@newLockScope
+    override val options: Options = Options(3, 2) /* 몇초가 최적일지는 테스트해보며 조절 */
+}
+
+interface LockScope<T> {
+    val lockContext: LockContext
+    val options: Options
+}
+
+data class LockContext(
+    val lockType: LockType,
+    val key: String,
+)

--- a/common/infrastructure/src/main/kotlin/com/gongsung/common/infrastructure/LockService.kt
+++ b/common/infrastructure/src/main/kotlin/com/gongsung/common/infrastructure/LockService.kt
@@ -1,0 +1,33 @@
+package com.gongsung.common.infrastructure
+
+import org.springframework.stereotype.Component
+
+private lateinit var container: LockTransactionContainer
+
+fun <T> withLock(
+    context: LockContext,
+    block: LockScope<T>.() -> T
+): Result<T> = container.eval(context.newLockScope(), block)
+
+@Component
+internal open class LockTransactionContainer(
+    private val lockTemplate: LockTemplate
+) {
+
+    open fun <T> eval(
+        scope: LockScope<T>,
+        block: LockScope<T>.() -> T
+    ): Result<T> =
+        scope.run {
+            lockTemplate.execute(lockContext, options){ block() }
+        }
+}
+
+@Component
+private class LockService private constructor(
+    lockTransactionContainer: LockTransactionContainer
+) {
+    init {
+        container = lockTransactionContainer
+    }
+}

--- a/common/infrastructure/src/main/kotlin/com/gongsung/common/infrastructure/LockTemplate.kt
+++ b/common/infrastructure/src/main/kotlin/com/gongsung/common/infrastructure/LockTemplate.kt
@@ -1,0 +1,5 @@
+package com.gongsung.common.infrastructure
+
+interface LockTemplate {
+    fun <T> execute(lockContext: LockContext, options: Options, block: () -> T): Result<T>
+}

--- a/common/infrastructure/src/main/kotlin/com/gongsung/common/infrastructure/redis/LockType.kt
+++ b/common/infrastructure/src/main/kotlin/com/gongsung/common/infrastructure/redis/LockType.kt
@@ -1,0 +1,9 @@
+package com.gongsung.common.infrastructure.redis
+
+enum class LockType(
+    val keyPrefix: String,
+) {
+
+    FEED_LIKE("FEED_LIKE:")
+    ;
+}

--- a/common/infrastructure/src/main/kotlin/com/gongsung/common/infrastructure/redis/RedisLockAdaptor.kt
+++ b/common/infrastructure/src/main/kotlin/com/gongsung/common/infrastructure/redis/RedisLockAdaptor.kt
@@ -1,0 +1,35 @@
+package com.gongsung.common.infrastructure.redis
+
+import com.gongsung.common.infrastructure.LockContext
+import com.gongsung.common.infrastructure.LockTemplate
+import com.gongsung.common.infrastructure.Options
+import org.redisson.api.RedissonClient
+import org.springframework.stereotype.Component
+import java.util.concurrent.TimeUnit
+
+@Component
+class RedisLockAdaptor(
+    private val redissonClient: RedissonClient,
+) : LockTemplate {
+
+    private val redisLockKeyGenerator = RedisLockKeyGenerator()
+
+    override fun <T> execute(
+        lockContext: LockContext,
+        options: Options,
+        block: () -> T
+    ): Result<T> {
+        val key : String = redisLockKeyGenerator.generate(lockContext.lockType, lockContext.key)
+
+        val lock = redissonClient.getFairLock(key)
+
+        if (!lock.tryLock(options.waitTimeout, options.releaseTimeout, TimeUnit.SECONDS)) {
+            return Result.failure(IllegalStateException("lock 획득 실패."))
+        }
+
+        return runCatching(block)
+            .also {
+                lock.unlock()
+            }
+    }
+}

--- a/common/infrastructure/src/main/kotlin/com/gongsung/common/infrastructure/redis/RedisLockKeyGenerator.kt
+++ b/common/infrastructure/src/main/kotlin/com/gongsung/common/infrastructure/redis/RedisLockKeyGenerator.kt
@@ -1,0 +1,8 @@
+package com.gongsung.common.infrastructure.redis
+
+class RedisLockKeyGenerator {
+
+    fun generate(lockType: LockType, key: String): String {
+        return lockType.keyPrefix + key
+    }
+}

--- a/common/infrastructure/src/main/kotlin/com/gongsung/common/infrastructure/redis/RedissonConfig.kt
+++ b/common/infrastructure/src/main/kotlin/com/gongsung/common/infrastructure/redis/RedissonConfig.kt
@@ -1,0 +1,26 @@
+package com.gongsung.common.infrastructure.redis
+
+import org.redisson.Redisson
+import org.redisson.api.RedissonClient
+import org.redisson.config.Config
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+open class RedissonConfig {
+
+    @Value("\${spring.data.redis.host}")
+    lateinit var redisHost: String
+
+    @Value("\${spring.data.redis.port}")
+    lateinit var redisPort: String
+
+    @Bean
+    open fun redissonClient(): RedissonClient {
+        val config: Config = Config()
+
+        config.useSingleServer().setAddress("redis://$redisHost:$redisPort")
+        return Redisson.create(config)
+    }
+}

--- a/common/infrastructure/src/main/resources/application.yml
+++ b/common/infrastructure/src/main/resources/application.yml
@@ -1,0 +1,9 @@
+spring.config.activate.on-profile: local
+
+spring:
+  data:
+    redis:
+      host: 127.0.0.1
+      port: 6379
+
+---

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,6 +3,7 @@ rootProject.name = "meet-in"
 include(":application")
 
 include("common:exception")
+include("common:infrastructure")
 
 include("hello-world:api")
 include("hello-world:internal-api")


### PR DESCRIPTION
### 개발 기능
- Redisson 라이브러리에서 제공해주는 lock 이용하여 분산락을 적용할 수 있도록 환경 마련

### 상세 내용
- redis 연결 설정은 일단 기본값들로 설정
- wait timeout = 3초, release timeout = 2초
- Key 규칙은 `LockType` enum에 명시하도록 함
- withLock 이라는 최상위 메소드를 두고, 내부 lock 구현은 모른채 lock 간단하게 사용할 수 있도록 함
- ex)
```kotlin
withLock(LockType.FEED_LIKE, id) {
    // lock 필요한 비즈니스 로직
}
```